### PR TITLE
added a log box ignore

### DIFF
--- a/kinderkitchen/App.js
+++ b/kinderkitchen/App.js
@@ -1,4 +1,6 @@
 import { NavigationContainer } from "@react-navigation/native";
+import { LogBox } from "react-native";
+LogBox.ignoreLogs(["Setting a timer for a long period of time"]);
 
 import MyStack from "./routes/MyStack";
 


### PR DESCRIPTION
There may be a further underlying issue when using getAuth() / getDatabase from firebase that triggers the timer token.
this will hide the log box so it doesn't show during demo

Resources that describe similar issues:
https://github.com/facebook/react-native/issues/12981
https://github.com/firebase/firebase-js-sdk/issues/97
https://stackoverflow.com/questions/44603362/setting-a-timer-for-a-long-period-of-time-i-e-multiple-minutes